### PR TITLE
Refactor KSQLDBClient usage to support new query return type (openfactoryio/openfactory-core#37)

### DIFF
--- a/routing_layer/app/core/controller/unslevel_grouping_strategy.py
+++ b/routing_layer/app/core/controller/unslevel_grouping_strategy.py
@@ -132,8 +132,9 @@ class UNSLevelGroupingStrategy(GroupingStrategy):
         FROM {settings.ksqldb_uns_map};
         """
         try:
-            df = ksql.query(query)
-            return df['GROUPS'].dropna().unique().tolist()
+            rows = ksql.query(query)
+            groups = [row.get("GROUPS") for row in rows if row.get("GROUPS")]
+            return list(set(groups))  # deduplicate
         except Exception as e:
             logger.error(f"Error querying all groups: {e}")
             return []
@@ -154,8 +155,9 @@ class UNSLevelGroupingStrategy(GroupingStrategy):
         WHERE UNS_LEVELS['{self.grouping_level}'] = '{escape_ksql_literal(group_name)}';
         """
         try:
-            df = ksql.query(query)
-            return df['ASSET_UUID'].dropna().unique().tolist()
+            rows = ksql.query(query)
+            assets = [row.get("ASSET_UUID") for row in rows if row.get("ASSET_UUID")]
+            return list(set(assets))  # deduplicate
         except Exception as e:
             logger.error(f"Error querying all assets from group {group_name}: {e}")
             return []


### PR DESCRIPTION
### **PR Description**

#### 📌 Context

Upstream change in [`[openfactory-core](https://github.com/openfactoryio/openfactory-core/issues/37)`](https://github.com/openfactoryio/openfactory-core/issues/37) modified the `KSQLDBClient.query()` method to return `list[dict]` instead of a pandas `DataFrame`.

This broke several places in this repo where DataFrame operations (`.empty`, `.iloc`, `.iterrows()`, `.dropna()`, `.unique()`, etc.) were used directly.

#### 🔧 Changes

* Refactored all usages of `ksql.query()` to work with `list[dict]`:

  * `get_all_groups` → extract `GROUPS` values via list comprehension instead of DataFrame ops.
  * `get_all_assets_in_group` → extract `ASSET_UUID` values manually.
  * `/asset_state` API endpoint → replaced DataFrame logic (`.empty`, `.iloc`, `.iterrows()`) with direct list/dict handling.

#### ✅ Impact

* Functional behavior remains the same: results are still returned as JSON with the same structure.
* Only the internal handling of query results changed.
* Deduplication of values is now done with `set()` instead of `.unique()`.
* Proper 404/500 handling preserved.

#### 🔗 Related

* Upstream change: openfactoryio/openfactory-core#37